### PR TITLE
Add Icinga to list supported monitoring systems

### DIFF
--- a/lib/logstash/outputs/nagios.rb
+++ b/lib/logstash/outputs/nagios.rb
@@ -3,7 +3,7 @@ require "logstash/namespace"
 require "logstash/outputs/base"
 
 # The Nagios output is used for sending passive check results to Nagios via the
-# Nagios command file. This output currently supports Nagios 3.
+# Nagios command file. This output currently supports Nagios 3, Icinga 1 and Icinga 2.
 #
 # For this output to work, your event _must_ have the following Logstash event fields:
 #


### PR DESCRIPTION
Hi,

I just added Icinga 1 and Icinga 2 as supported monitoring systems to the documentation.

Maybe you could add this without me signing the CLA because I'm waiting for the decision whether we will be signing as a company, as project or if I should sign as an individual developer.

Cheers,
Thomas